### PR TITLE
Fixed to disable rubocop class length check for test

### DIFF
--- a/rubocop.test.yml
+++ b/rubocop.test.yml
@@ -24,4 +24,3 @@ Naming/VariableNumber:
 Metrics/ClassLength:
   Exclude:
     - 'test/**/*_test.rb' # minitest
-    - 'spec/**/*_spec.rb' # RSpec

--- a/rubocop.test.yml
+++ b/rubocop.test.yml
@@ -22,4 +22,6 @@ Naming/VariableNumber:
   - 'spec/**/*_spec.rb' # RSpec
 
 Metrics/ClassLength:
-  Enabled: false
+  Exclude:
+    - 'test/**/*_test.rb' # minitest
+    - 'spec/**/*_spec.rb' # RSpec

--- a/rubocop.test.yml
+++ b/rubocop.test.yml
@@ -21,3 +21,5 @@ Naming/VariableNumber:
   - 'test/**/*_test.rb' # minitest
   - 'spec/**/*_spec.rb' # RSpec
 
+Metrics/ClassLength:
+  Enabled: false


### PR DESCRIPTION
In Minitest class length rule is not important. Therefore test files should be able to ignore the rule. (current master branch is missing the setting)