### PR TITLE
feat: allow method length to be up to 15

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -7,6 +7,9 @@ Style/SymbolArray:
 Metrics/LineLength:
   Max: 120
 
+Metrics/MethodLength:
+  Max: 15
+
 Layout/MultilineMethodCallIndentation:
   EnforcedStyle: indented_relative_to_receiver
 


### PR DESCRIPTION
## Why is this patch necessary

Upon discussion with a few members of the Engineering team, we feel it is reasonable to extend the MethodLength from `10` to `15`, considering that 15 LOC is still comprehendible for the code reviewer.


## Use cases

<!-- List examples of why this is useful -->

## Pre-Requisites

- [ ] Update CHANGELOG.md

## Post-Requisites

- [ ] Release new version <!-- Delete this line if there is only trivial changes such as documentation or formatting --> 
