### PR TITLE
Fix repo reference in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ TODO: write development instructions here
 
 ## Contributing
 
-Bug reports and pull requests are welcome on GitHub at https://github.com/moneytree/moneytree-rubocop-config.
+Bug reports and pull requests are welcome on GitHub at https://github.com/moneytree/rubocop-config.
 
 ## License
 


### PR DESCRIPTION
Assuming this repo got renamed at some point, this fixes the reference to the repo in the readme.