### PR TITLE
Upgrade rubocop and rubocop-rails

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,6 @@ executors:
     working_directory: ~/project
     environment:
       BUNDLE_PATH: ~/project/vendor/bundle
-      BUNDLER_VERSION: '2.0.1'
 
 commands:
   restore_bundle_cache:
@@ -21,7 +20,7 @@ commands:
 
   bundle_install:
     steps:
-      - run: gem install "bundler:${BUNDLER_VERSION}"
+      - run: gem install "bundler:$(grep -A 1 'BUNDLED WITH' Gemfile.lock | tail -n 1 | awk '{ print $1 }')"
       - run: bundle install --path "${BUNDLE_PATH}"
 
   save_bundle_cache:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+# Unreleased
+
+<!-- To release, add a new H1 tag of version, and move the Unreleased ones to that new section. Keep Unreleased section empty. -->
+
+- Require `rubocop >= 0.81.0`
+- Require `ruboco-rails >= 2.5.0`
+- Enabled these cops:
+    - `Lint/RaiseException`
+    - `Lint/StructNewOverride`
+    - `Style/HashEachMethods`
+    - `Style/HashTransformKeys`
+    - `Style/HashTransformValues`
+
 # 1.0.2
 
 - `Layout/IndentFirstHashElement` is deprecated. Use `Layout/FirstHashElementIndentation` instead.
@@ -7,7 +20,7 @@
 
 # 1.0.1
 
-- `Metrics/ClassLength` will not be applied to MiniTest files anymore. (`rubocop.test.yml`) #2 
+- `Metrics/ClassLength` will not be applied to MiniTest files anymore. (`rubocop.test.yml`) #2
 
 # 1.0.0
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,32 +2,49 @@ PATH
   remote: .
   specs:
     moneytree-rubocop-config (1.0.0)
-      rubocop (~> 0.79.0)
-      rubocop-rails (~> 2.4.2)
+      rubocop (>= 0.81.0)
+      rubocop-rails (>= 2.5.0)
 
 GEM
   remote: https://rubygems.org/
   specs:
+    activesupport (6.0.2.2)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      i18n (>= 0.7, < 2)
+      minitest (~> 5.1)
+      tzinfo (~> 1.1)
+      zeitwerk (~> 2.2)
     ast (2.4.0)
+    concurrent-ruby (1.1.6)
+    i18n (1.8.2)
+      concurrent-ruby (~> 1.0)
     jaro_winkler (1.5.4)
+    minitest (5.14.0)
     parallel (1.19.1)
-    parser (2.7.0.2)
+    parser (2.7.0.5)
       ast (~> 2.4.0)
-    rack (2.1.2)
+    rack (2.2.2)
     rainbow (3.0.0)
     rake (12.3.3)
-    rubocop (0.79.0)
+    rexml (3.2.4)
+    rubocop (0.81.0)
       jaro_winkler (~> 1.5.1)
       parallel (~> 1.10)
       parser (>= 2.7.0.1)
       rainbow (>= 2.2.2, < 4.0)
+      rexml
       ruby-progressbar (~> 1.7)
-      unicode-display_width (>= 1.4.0, < 1.7)
-    rubocop-rails (2.4.2)
+      unicode-display_width (>= 1.4.0, < 2.0)
+    rubocop-rails (2.5.0)
+      activesupport
       rack (>= 1.1)
       rubocop (>= 0.72.0)
     ruby-progressbar (1.10.1)
-    unicode-display_width (1.6.1)
+    thread_safe (0.3.6)
+    tzinfo (1.2.6)
+      thread_safe (~> 0.1)
+    unicode-display_width (1.7.0)
+    zeitwerk (2.3.0)
 
 PLATFORMS
   ruby
@@ -38,4 +55,4 @@ DEPENDENCIES
   rake (~> 12.3)
 
 BUNDLED WITH
-   2.0.2
+   2.1.4

--- a/moneytree-rubocop-config.gemspec
+++ b/moneytree-rubocop-config.gemspec
@@ -36,8 +36,8 @@ Gem::Specification.new do |spec|
                      .reject { |f| f.match(%r{^(test|spec|features)/}) }
   end
 
-  spec.add_runtime_dependency 'rubocop', '~> 0.79.0'
-  spec.add_runtime_dependency 'rubocop-rails', '~> 2.4.2'
+  spec.add_runtime_dependency 'rubocop', '>= 0.81.0'
+  spec.add_runtime_dependency 'rubocop-rails', '>= 2.5.0'
 
   spec.add_development_dependency 'bundler', '~> 2.0'
   spec.add_development_dependency 'rake', '~> 12.3'

--- a/rubocop.yml
+++ b/rubocop.yml
@@ -1,5 +1,11 @@
 # Defaults: https://github.com/bbatsov/rubocop/blob/master/config/default.yml
 
+Lint/RaiseException:
+  Enabled: true
+
+Lint/StructNewOverride:
+  Enabled: true
+
 # Accept both [:a, :b, :c] and %i[a b c]
 Style/SymbolArray:
   Enabled: false
@@ -40,3 +46,12 @@ Style/ConditionalAssignment:
 # Disallow %w[]
 Style/WordArray:
   Enabled: false
+
+Style/HashEachMethods:
+  Enabled: true
+
+Style/HashTransformKeys:
+  Enabled: true
+
+Style/HashTransformValues:
+  Enabled: true


### PR DESCRIPTION
## Why is this patch necessary

- To use the latest version of rubocop and rubocop-rails
- To improve locking of version number. We used to use `~> 0.xx.0` but it prevents the consumer to use the newer version of Rubocop. This patch changes the condition to `>=` so that the consumer can install a newer version

This version also fixes CircleCI config so that it uses the bundler of the version that was used to run `bundle install`, instead of hard-coded version in the config file. (The complicated grep-awk part)

## Use cases

<!-- List examples of why this is useful -->

5 new cops has been enabled. See docs for details:

* [Lint/RaiseException](https://rubocop.readthedocs.io/en/latest/cops_lint/#lintraiseexception)
* [Lint/StructNewOverride](https://rubocop.readthedocs.io/en/latest/cops_lint/#lintstructnewoverride)
* [Style/HashEachMethods](https://rubocop.readthedocs.io/en/latest/cops_style/#stylehasheachmethods)
* [Style/HashTransformKeys](https://rubocop.readthedocs.io/en/latest/cops_style/#stylehashtransformkeys)
* [Style/HashTransformValues](https://rubocop.readthedocs.io/en/latest/cops_style/#stylehashtransformvalues)

## Pre-Requisites

- [x] Update CHANGELOG.md

## Post-Requisites

- [ ] Release new version <!-- Delete this line if there is only trivial changes such as documentation or formatting --> 
