### PR TITLE
version bump to 1.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 <!-- To release, add a new H1 tag of version, and move the Unreleased ones to that new section. Keep Unreleased section empty. -->
 
+# 1.0.3
+
 - Require `rubocop >= 0.81.0`
 - Require `ruboco-rails >= 2.5.0`
 - Enabled these cops:

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    moneytree-rubocop-config (1.0.0)
+    moneytree-rubocop-config (1.0.3)
       rubocop (>= 0.81.0)
       rubocop-rails (>= 2.5.0)
 

--- a/moneytree-rubocop-config.gemspec
+++ b/moneytree-rubocop-config.gemspec
@@ -5,7 +5,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name          = 'moneytree-rubocop-config'
-  spec.version       = '1.0.0'
+  spec.version       = '1.0.3'
   spec.authors       = ['Moneytree']
   spec.email         = ['support@moneytree.jp']
 


### PR DESCRIPTION
## Why is this patch necessary

To bump version to 1.0.3

## Use cases


## Pre-Requisites

- [x] Update CHANGELOG.md

## Post-Requisites

- [x] Tag `v1.0.3`