### PR TITLE
Disable Style/ZeroLengthPredicate & Style/NumericPredicate that are not helping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 <!-- To release, add a new H1 tag of version, and move the Unreleased ones to that new section. Keep Unreleased section empty. -->
 
+- Disable these cops:
+    - `Style/ZeroLengthPredicate`
+    - `Style/NumericPredicate`
+
 # 1.0.3
 
 - Require `rubocop >= 0.81.0`

--- a/rubocop.yml
+++ b/rubocop.yml
@@ -55,3 +55,12 @@ Style/HashTransformKeys:
 
 Style/HashTransformValues:
   Enabled: true
+
+# It sometimes make sense to use #length == 0 or #size == 0, for example, when the object does not implement Enumerable.
+Style/ZeroLengthPredicate:
+  Enabled: false
+
+# > 0, == 0, < 0 is more common in major programming languages.
+# In addition, sometimes it is necessary to compare a non-numeric value with 0 (e.g. params[:size] == 0 but it can be nil)
+Style/NumericPredicate:
+  Enabled: false


### PR DESCRIPTION
## Why is this patch necessary

Disable numeric method checkers that are not helping us that much.

- Style/ZeroLengthPredicate
- Style/NumericPredicate

Reasons for this proposal:

1. It is very common in other languages to compare numeric values with `== 0`, `> 0`, `< 0`. Since we have many developers from variety of backgrounds, there is no need to create another convention just for Ruby.
2. Sometimes we need to compare non-numeric value with `0`, for example, a `nil`. In which case, it does not implement `#zero?` and raises error if we follow what RuboCop enforces us to do.
3. Saying "zero is not positive" may cause confusion in [some natural languages](https://math.stackexchange.com/questions/26705/is-zero-positive-or-negative) and even [mathematical definition](https://math.stackexchange.com/questions/18464/is-positive-the-same-as-non-negative).
4. Using `.empty?` implies that we assume the object implements Enumerable module, but this may be a false assumption in extreme cases.

By disabling these cops, developers are free to choose to use `collection.empty?`, `number.zero?`, `number.positive?`, `number.negative?`, or `== 0`, `> 0`, `< 0` operators, depend on their scenario.

## Use cases

```rb
# Suppose that params[:size] can be nil or a Number (not a String)
params[:size] == 0 # true or false, deterministic
params[:size].zero? # This raises an error when nil
```

## Pre-Requisites

- [x] Update CHANGELOG.md

## Post-Requisites

- [ ] Release new version <!-- Delete this line if there is only trivial changes such as documentation or formatting --> 
